### PR TITLE
更新链接

### DIFF
--- a/resources/WECHAT.md
+++ b/resources/WECHAT.md
@@ -5,3 +5,6 @@
 <p> Scan the QR code to follow the official account and join the "ChatGLM Discussion Group" </p>
 </div>
 
+或者直接扫码加入本群
+
+![image](https://github.com/sudo888samewick/GLM-4/assets/150644414/7b1cac03-5651-4a1e-aa6f-83678f572e4a)


### PR DESCRIPTION
在 GLM4 发布后的半小时内，Readme 指引的官方微信群是满员的，添加不了。有社区小伙伴提出 issue 

https://github.com/THUDM/GLM-4/issues/1

并且当时附上了一个子群链接

然后我感到疑问，没太弄清楚

![image](https://github.com/THUDM/GLM-4/assets/150644414/2591d259-acb4-4261-ab95-05f55b030562)

此时已有很多小伙伴进入了子群。 

幸而 GLM 团队迅速修复了故障，https://github.com/THUDM/GLM-4/issues/2

![image](https://github.com/THUDM/GLM-4/assets/150644414/c04ef899-b640-4ae4-b496-9331a0eda858)

（但是为什么要删我评呀哈哈）

本 PR 整合了新的群链接，更新了最新的官方群链接

（话说 GLM4 的第一个 issue 竟然是社区群翻车，有点绷^_^） 但GLM模型还是很好滴！
