### PR TITLE
Fix openai_api_server request_id issue

### DIFF
--- a/basic_demo/openai_api_server.py
+++ b/basic_demo/openai_api_server.py
@@ -195,7 +195,7 @@ async def generate_stream_glm4(params):
         "skip_special_tokens": True,
     }
     sampling_params = SamplingParams(**params_dict)
-    async for output in engine.generate(inputs=inputs, sampling_params=sampling_params, request_id="glm-4-9b"):
+    async for output in engine.generate(inputs=inputs, sampling_params=sampling_params, request_id=f"{time.time()}"):
         output_len = len(output.outputs[0].token_ids)
         input_len = len(output.prompt_token_ids)
         ret = {


### PR DESCRIPTION
add request_id=f"{time.time()}" to Fix API concurrency request issue

If a fixed request_id is used, conflicts will be encountered in multiple requests.

Tested fine

![image](https://github.com/THUDM/GLM-4/assets/69239617/fac1991b-83b5-4100-be52-8326fcad9a7a)
