### PR TITLE
Issues about Ray under WSL

### DIFF
--- a/basic_demo/openai_api_server.py
+++ b/basic_demo/openai_api_server.py
@@ -540,7 +540,7 @@ if __name__ == "__main__":
         trust_remote_code=True,
         gpu_memory_utilization=0.9,
         enforce_eager=True,
-        worker_use_ray=True,
+        worker_use_ray=True, # Set to False if you use wsl2 and encounter UnicodeDecodeError. Until https://github.com/ray-project/ray/issues/45492 is fixed.
         engine_use_ray=False,
         disable_log_requests=True,
         max_model_len=MAX_MODEL_LENGTH,


### PR DESCRIPTION
Add notes for wsl

ref : https://github.com/ray-project/ray/issues/45492

## Issue with NVIDIA Drivers and WSL2 Environment

When using the latest NVIDIA drivers and the WSL2 environment, setting `worker_use_ray=True` may result in a `UnicodeDecodeError`. To avoid this issue, please set `worker_use_ray` to `False` until the next version of the driver or a fix from Ray is released.
![image](https://github.com/THUDM/GLM-4/assets/69239617/d3a67703-61f6-4797-b598-8079a5b2cc4f)

<img width="829" alt="3b283b09e504c29005af30ab7dd1d4f" src="https://github.com/THUDM/GLM-4/assets/69239617/b6634694-f105-4a93-ae4c-9a4f8798ff43">
