### PR TITLE
修复composite_demo中的openai client 缺失system_prompt的问题

### DIFF
--- a/composite_demo/src/client.py
+++ b/composite_demo/src/client.py
@@ -37,10 +37,10 @@ class Client(Protocol):
 
 def process_input(history: list[dict], tools: list[dict], role_name_replace:dict=None) -> list[dict]:
     chat_history = []
-    if len(tools) > 0:
-        chat_history.append(
-            {"role": "system", "content": build_system_prompt(list(ALL_TOOLS), tools)}
-        )
+    #if len(tools) > 0:
+    chat_history.append(
+        {"role": "system", "content": build_system_prompt(list(ALL_TOOLS), tools)}
+    )
 
     for conversation in history:
         role = str(conversation.role).removeprefix("<|").removesuffix("|>")

--- a/composite_demo/src/clients/openai.py
+++ b/composite_demo/src/clients/openai.py
@@ -43,12 +43,12 @@ class APIClient(Client):
         history: list[Conversation],
         **parameters,
     ) -> Generator[tuple[str | dict, list[dict]]]:
-        chat_history = process_input(history, tools)
-        messages = process_input(history, '', role_name_replace=self.role_name_replace)
+        chat_history = process_input(history, '', role_name_replace=self.role_name_replace)
+        #messages = process_input(history, '', role_name_replace=self.role_name_replace)
         openai_tools = format_openai_tool(tools)
         response = self.client.chat.completions.create(
             model="glm-4",
-            messages=messages,
+            messages=chat_history,
             tools=openai_tools,
             stream=self.use_stream,
             max_tokens=parameters["max_new_tokens"],

--- a/composite_demo/src/conversation.py
+++ b/composite_demo/src/conversation.py
@@ -30,7 +30,8 @@ def build_system_prompt(
 ):
     value = SELFCOG_PROMPT
     value += "\n\n" + datetime.now().strftime(DATE_PROMPT)
-    value += "\n\n# 可用工具"
+    if enabled_tools or functions:
+        value += "\n\n# 可用工具"
     contents = []
     for tool in enabled_tools:
         contents.append(f"\n\n## {tool}\n\n{TOOL_SYSTEM_PROMPTS[tool]}")


### PR DESCRIPTION
**现象**
在composite_demo中，修改系统提示词，比如增加一个身份设定，但是调用openai接口发现没有生效


**问题分析**
调试的时候发现传给openai 的接口调用中，messages参数中缺少 role 是 system的提示词

因为openai接口有专门接收tools的参数，所以不用tools的描述不用放在系统提示词中，所以下行代码第二个参数为空
`messages = process_input(history, '', role_name_replace=self.role_name_replace)`

这样就导致
```
def process_input(history: list[dict], tools: list[dict], role_name_replace:dict=None) -> list[dict]:
    chat_history = []
    if len(tools) > 0:  ##该条件永远不满足，最终导致system提示词被遗漏
       chat_history.append(
            {"role": "system", "content": build_system_prompt(list(ALL_TOOLS), tools)}
        )
```

**修复方案**
参考代码，
1、去掉if len(tools) 判断，没有tools也应该要添加system提示词，对比了hf和vllm都是这样的，这样可以做到替换模型后保持效果的一致
2、在openai.py中合并  chat_history  和 messages