### PR TITLE
修复了 batch map 时默认批大小(1000)导致的 offset overflow 问题

### DIFF
--- a/finetune_demo/finetune_vision.py
+++ b/finetune_demo/finetune_vision.py
@@ -236,6 +236,8 @@ class DataManager(object):
             batched=batched,
             remove_columns=remove_columns,
             num_proc=self._num_proc,
+            batch_size=500,    # Dynamically adjust according to mem size
+            writer_batch_size=500
         )
 
 


### PR DESCRIPTION
修复 finetune_vision.py 处理数据集时的问题

`
orig_dataset.map(
            process_fn,
            batched=batched,
            remove_columns=remove_columns,
            num_proc=self._num_proc,
            batch_size=500,
            writer_batch_size=500
)

`

`
File "pyarrow/table.pxi", line 4289, in pyarrow.lib.Table.combine_chunks
File "pyarrow/error.pxi", line 154, in pyarrow.lib.pyarrow_internal_check_status
File "pyarrow/error.pxi", line 91, in pyarrow.lib.check_status
pyarrow.lib.ArrowInvalid: offset overflow while concatenating arrays
`