### PR TITLE
更新了新的Bing search customer API支持

### DIFF
--- a/composite_demo/README.md
+++ b/composite_demo/README.md
@@ -52,14 +52,13 @@ pnpm install
 
     ```diff
     export default {
-    LOG_LEVEL: 'debug',
-
-    BROWSER_TIMEOUT: 10000,
-    BING_SEARCH_API_URL: 'https://api.bing.microsoft.com/v7.0/custom/',
-    BING_SEARCH_API_KEY: 'YOUR_BING_SEARCH_API_KEY',
-    CUSTOM_CONFIG_ID :  'YOUR_CUSTOM_CONFIG_ID', //将您的Custom Configuration ID放在此处
-    HOST: 'localhost',
-    PORT: 3000,
+    
+        BROWSER_TIMEOUT: 10000,
+        BING_SEARCH_API_URL: 'https://api.bing.microsoft.com/v7.0/custom/',
+        BING_SEARCH_API_KEY: 'YOUR_BING_SEARCH_API_KEY',
+        CUSTOM_CONFIG_ID :  'YOUR_CUSTOM_CONFIG_ID', //将您的Custom Configuration ID放在此处
+        HOST: 'localhost',
+        PORT: 3000,
    };
     ```
 

--- a/composite_demo/README.md
+++ b/composite_demo/README.md
@@ -48,7 +48,7 @@ pnpm install
         PORT: 3000,
     };
     ```
-   如果您注册的是Bing Customer Search的API，您可以修改您的配置文件如下，并且填写您的Custom Configuration ID:
+   如果您注册的是Bing Customer Search的API，您可以修改您的配置文件为如下，并且填写您的Custom Configuration ID:
 
     ```diff
     export default {
@@ -57,7 +57,7 @@ pnpm install
     BROWSER_TIMEOUT: 10000,
     BING_SEARCH_API_URL: 'https://api.bing.microsoft.com/v7.0/custom/',
     BING_SEARCH_API_KEY: 'YOUR_BING_SEARCH_API_KEY',
-    CUSTOM_CONFIG_ID :  'YOUR_CUSTOM_CONFIG_ID', //将你的Custom Configuration ID放在此处
+    CUSTOM_CONFIG_ID :  'YOUR_CUSTOM_CONFIG_ID', //将您的Custom Configuration ID放在此处
     HOST: 'localhost',
     PORT: 3000,
    };

--- a/composite_demo/README.md
+++ b/composite_demo/README.md
@@ -48,6 +48,20 @@ pnpm install
         PORT: 3000,
     };
     ```
+   如果您注册的是Bing Customer Search的API，您可以修改您的配置文件如下，并且填写您的Custom Configuration ID:
+
+    ```diff
+    export default {
+    LOG_LEVEL: 'debug',
+
+    BROWSER_TIMEOUT: 10000,
+    BING_SEARCH_API_URL: 'https://api.bing.microsoft.com/v7.0/custom/',
+    BING_SEARCH_API_KEY: 'YOUR_BING_SEARCH_API_KEY',
+    CUSTOM_CONFIG_ID :  'YOUR_CUSTOM_CONFIG_ID', //将你的Custom Configuration ID放在此处
+    HOST: 'localhost',
+    PORT: 3000,
+   };
+    ```
 
 2. 文生图功能需要调用 CogView API。修改 `src/tools/config.py`
    ，提供文生图功能需要使用的 [智谱 AI 开放平台](https://open.bigmodel.cn) API Key：

--- a/composite_demo/README.md
+++ b/composite_demo/README.md
@@ -52,7 +52,7 @@ pnpm install
 
     ```diff
     export default {
-    
+        LOG_LEVEL: 'debug',
         BROWSER_TIMEOUT: 10000,
         BING_SEARCH_API_URL: 'https://api.bing.microsoft.com/v7.0/custom/',
         BING_SEARCH_API_KEY: 'YOUR_BING_SEARCH_API_KEY',

--- a/composite_demo/browser/src/browser.ts
+++ b/composite_demo/browser/src/browser.ts
@@ -172,7 +172,9 @@ abstract class BaseBrowser {
       logger.debug(`Searching for: ${query}`);
       const search = new URLSearchParams({ q: query });
       recency_days > 0 && search.append('recency_days', recency_days.toString());
-      search.append('customconfig', config.CUSTOM_CONFIG_ID);
+       if (config.CUSTOM_CONFIG_ID !== undefined) {
+        search.append('customconfig', config.CUSTOM_CONFIG_ID);
+    }
       const url = `${config.BING_SEARCH_API_URL}/search?${search.toString()}`;
       console.log('Full URL:', url); // 输出完整的 URL查看是否正确
 

--- a/composite_demo/browser/src/browser.ts
+++ b/composite_demo/browser/src/browser.ts
@@ -172,13 +172,18 @@ abstract class BaseBrowser {
       logger.debug(`Searching for: ${query}`);
       const search = new URLSearchParams({ q: query });
       recency_days > 0 && search.append('recency_days', recency_days.toString());
+      search.append('customconfig', config.CUSTOM_CONFIG_ID);
+      const url = `${config.BING_SEARCH_API_URL}/search?${search.toString()}`;
+      console.log('Full URL:', url); // 输出完整的 URL查看是否正确
+
       return withTimeout(
         config.BROWSER_TIMEOUT,
-        fetch(`${config.BING_SEARCH_API_URL}/search?${search.toString()}`, {
+        fetch(url, {
           headers: {
             'Ocp-Apim-Subscription-Key': config.BING_SEARCH_API_KEY,
           }
-        }).then(
+        })
+            .then(
           res =>
             res.json() as Promise<{
               queryContext: {
@@ -255,11 +260,11 @@ abstract class BaseBrowser {
           }
         })
         .catch(err => {
-          logger.error(err.message);
+          logger.error(`搜索请求失败：${query}，错误信息：${err.message}`);
           if (err.code === 'ECONNABORTED') {
             throw new Error(`Timeout while executing search for: ${query}`);
           }
-          throw new Error(`Network or server error occurred`);
+          throw new Error(`网络或服务器发生错误，请检查URL: ${url}`);
         });
     },
     open_url: (url: string) => {

--- a/composite_demo/browser/src/browser.ts
+++ b/composite_demo/browser/src/browser.ts
@@ -172,9 +172,9 @@ abstract class BaseBrowser {
       logger.debug(`Searching for: ${query}`);
       const search = new URLSearchParams({ q: query });
       recency_days > 0 && search.append('recency_days', recency_days.toString());
-       if (config.CUSTOM_CONFIG_ID !== undefined) {
-        search.append('customconfig', config.CUSTOM_CONFIG_ID);
-    }
+      if (config.CUSTOM_CONFIG_ID) {
+    search.append('customconfig', config.CUSTOM_CONFIG_ID.toString());
+}
       const url = `${config.BING_SEARCH_API_URL}/search?${search.toString()}`;
       console.log('Full URL:', url); // 输出完整的 URL查看是否正确
 

--- a/composite_demo/browser/src/config.ts
+++ b/composite_demo/browser/src/config.ts
@@ -3,7 +3,7 @@ export default {
     BROWSER_TIMEOUT: 10000,
     BING_SEARCH_API_URL: 'https://api.bing.microsoft.com/v7.0/custom/',
     BING_SEARCH_API_KEY: 'YOUR_BING_SEARCH_API_KEY',
-    CUSTOM_CONFIG_ID :  'YOUR_CUSTOM_CONFIG_ID', //将你的Custom Configuration ID放在此处
+    CUSTOM_CONFIG_ID :  'YOUR_CUSTOM_CONFIG_ID', //将您的Custom Configuration ID放在此处
     HOST: 'localhost',
     PORT: 3000,
 };

--- a/composite_demo/browser/src/config.ts
+++ b/composite_demo/browser/src/config.ts
@@ -2,9 +2,9 @@ export default {
     LOG_LEVEL: 'debug',
 
     BROWSER_TIMEOUT: 10000,
-    BING_SEARCH_API_URL: 'https://api.bing.microsoft.com/',
-    BING_SEARCH_API_KEY: '',
-
+    BING_SEARCH_API_URL: 'https://api.bing.microsoft.com/v7.0/custom/',
+    BING_SEARCH_API_KEY: 'YOUR_BING_SEARCH_API_KEY',
+    CUSTOM_CONFIG_ID :  'YOUR_CUSTOM_CONFIG_ID', //将你的Custom Configuration ID放在此处
     HOST: 'localhost',
     PORT: 3000,
 };

--- a/composite_demo/browser/src/config.ts
+++ b/composite_demo/browser/src/config.ts
@@ -1,6 +1,5 @@
 export default {
     LOG_LEVEL: 'debug',
-
     BROWSER_TIMEOUT: 10000,
     BING_SEARCH_API_URL: 'https://api.bing.microsoft.com/v7.0/custom/',
     BING_SEARCH_API_KEY: 'YOUR_BING_SEARCH_API_KEY',
@@ -8,3 +7,5 @@ export default {
     HOST: 'localhost',
     PORT: 3000,
 };
+
+


### PR DESCRIPTION
更新了新的Bing search customer API支持,用户只需要根据不同类型的Bing search API进行配置config.ts文件即可使用联网搜索功能。Bing search customer API能够支援免费的使用方案。 我修改了部分的Broswer.ts的代码以兼容两种不同的API方案，以及再README中增加了解释。