### PR TITLE
解决finetune.py在加载配置文件时的错误

### DIFF
--- a/finetune_demo/finetune.py
+++ b/finetune_demo/finetune.py
@@ -130,6 +130,7 @@ class FinetuningConfig(object):
     max_input_length: int
     max_output_length: int
     combine: bool
+    freezeV: bool
 
     training_args: Seq2SeqTrainingArguments = dc.field(
         default_factory=lambda: Seq2SeqTrainingArguments(output_dir='./output')


### PR DESCRIPTION
上一个[commit](https://github.com/THUDM/GLM-4/commit/1c2676415c213f534161da6ecc1d4b2de5be8caf)在配置文件添加了freezeV选项，但在finetune.py中没有支持。



暂时添加一句占位吧，虽然这个选项对纯文本微调没啥用