### PR TITLE
修复微调代码README的描述错误fix docs name err

### DIFF
--- a/finetune/README.md
+++ b/finetune/README.md
@@ -38,7 +38,7 @@ All fine-tuning tests were performed in the following environment:
 
 ## Preparation
 
-Before starting fine-tuning, please install the dependencies in \`basic_demo\`, ensure you have cloned the latest version of the model repository, and install the dependencies in this directory:
+Before starting fine-tuning, please install the dependencies in \`inference\`, ensure you have cloned the latest version of the model repository, and install the dependencies in this directory:
 
 ```bash
 pip install -r requirements.txt


### PR DESCRIPTION
# Contribution Guide

本次只是一个小的改动，因此我简化了提交文案。修复了finetune/README.md中关于环境安装的描述错误，实际路径应该是inference文件夹而非basic_demo文件夹。具体修改内容请查看我的文档改动。
This is a minor change, so I've simplified the submission message. The environment installation description in finetune/README.md contained an error - the actual path should point to the inference folder rather than basic_demo. Please refer to my documentation changes for details.


