### PR TITLE
 修复微调配置项中的 Deepspeed config 路径错误 Fix incorrect Deepspeed config path in finetuning configuration

### DIFF
--- a/finetune/configs/lora.yaml
+++ b/finetune/configs/lora.yaml
@@ -40,7 +40,7 @@ training_args:
     max_new_tokens: 512
   # set your absolute deepspeed path here
   # deepspeed: configs/ds_zero_3.json
-  deepspeed: /data/yuxuan/GLM-4/finetune/configs/ds_zero_2.json
+  deepspeed: configs/ds_zero_2.json
 
 peft_config:
   peft_type: LORA


### PR DESCRIPTION
# Contribution Guide

在 finetune 代码的配置文件 lora.yaml 中，原先错误地使用了绝对路径来配置 Deepspeed 脚本路径。此次修改将该路径修正为相对路径。

In the finetune code, the lora.yaml configuration file previously used an absolute path to specify the Deepspeed config script. This has been corrected to a relative path.
